### PR TITLE
More docs with examples and use Evaluator from generated

### DIFF
--- a/getcontext/tracing/__init__.py
+++ b/getcontext/tracing/__init__.py
@@ -1,3 +1,4 @@
-from ._tools import *
+from ._tools import capture_trace
 from .trace import *
 from langsmith import traceable
+from getcontext.generated.models import Evaluator

--- a/getcontext/tracing/_tools.py
+++ b/getcontext/tracing/_tools.py
@@ -9,7 +9,11 @@ from getcontext.tracing.trace import Trace
 # TASK: Try capture gloabl langsmith client, change on begin capture trace and end capture trace
 # Looks like clients try to connect on instantiation, unknown if there is a way to override this
 
-def capture_trace(func, *args, **kwargs):
+DEVELOPMENT_ENDPOINT = "http://api.localtest.me:3000/api/v1/evaluations/traces"
+PRODUCTION_ENDPOINT = "https://with.context.ai/api/v1/evaluations/traces"
+
+
+def capture_trace(func, *args, **kwargs) -> Trace:
     """
     Capture a trace of the given function execution.
 
@@ -46,8 +50,8 @@ def capture_trace(func, *args, **kwargs):
 
 def __context_enviromental_variables():
     return {
-        "LANGCHAIN_ENDPOINT": "http://api.localtest.me:3000/api/v1/evaluations/traces" if os.environ.get("CONTEXT_SDK_DEV") else "https://with.context.ai/api/v1/evaluations/traces",
-        "LANGCHAIN_API_KEY": os.environ.get("GETCONTEXT_TOKEN"),
+        "LANGCHAIN_ENDPOINT": __context_endpoint(),
+        "LANGCHAIN_API_KEY": __context_API_key(),
         "LANGCHAIN_TRACING_V2": "true",
     }
 
@@ -61,3 +65,11 @@ def __find_test_parent_function_name():
             return frame.function
         
     raise ValueError("No test function found in stack. Make sure your test name starts or ends with 'test'.")
+
+
+def __context_endpoint():
+    return DEVELOPMENT_ENDPOINT if os.environ.get("CONTEXT_SDK_DEV") else PRODUCTION_ENDPOINT
+
+
+def __context_API_key():
+    return os.environ.get("GETCONTEXT_TOKEN")

--- a/getcontext/tracing/_tools.py
+++ b/getcontext/tracing/_tools.py
@@ -9,8 +9,7 @@ from getcontext.tracing.trace import Trace
 # TASK: Try capture gloabl langsmith client, change on begin capture trace and end capture trace
 # Looks like clients try to connect on instantiation, unknown if there is a way to override this
 
-DEVELOPMENT_ENDPOINT = "http://api.localtest.me:3000/api/v1/evaluations/traces"
-PRODUCTION_ENDPOINT = "https://with.context.ai/api/v1/evaluations/traces"
+CONTEXT_TRACE_ENDPOINT = "https://with.context.ai/api/v1/evaluations/traces"
 
 
 def capture_trace(func, *args, **kwargs) -> Trace:
@@ -68,7 +67,7 @@ def __find_test_parent_function_name():
 
 
 def __context_endpoint():
-    return DEVELOPMENT_ENDPOINT if os.environ.get("CONTEXT_SDK_DEV") else PRODUCTION_ENDPOINT
+    return os.environ.get("CONTEXT_TRACE_ENDPOINT", CONTEXT_TRACE_ENDPOINT)
 
 
 def __context_API_key():

--- a/getcontext/tracing/trace.py
+++ b/getcontext/tracing/trace.py
@@ -1,16 +1,58 @@
 from langsmith.run_trees import RunTree
+from typing import Any
+from getcontext.generated.models import Evaluator
 
 
 class Trace:
+    """
+    Represents a trace object used for adding evaluators to spans in a run tree.
+    
+    Args:
+        result (Any): The result of the trace.
+        run_tree (RunTree): The run tree of the trace.
+    """
+
     # known key, which is interpreted on the server side
     CONTEXT_AI_OPTIONS = "context_ai_options"
     
-    def __init__(self, result, run_tree: RunTree):
+    def __init__(self, result: Any, run_tree: RunTree):
         self.result = result
         self.run_tree = run_tree
     
-    # TODO: used typed stuff from sdk here
-    def add_evaluator(self, span_name: str, evaluator: dict):        
+    def add_evaluator(self, span_name: str, evaluator: Evaluator):
+        """
+        Adds an evaluator to the specified span in the run tree.
+
+        Args:
+            span_name (str): The name of the span to add the evaluator to.
+            evaluator (Evaluator): The evaluator to add to the span.
+
+        Raises:
+            ValueError: If the span_name is the same as the unit test function name.
+            ValueError: If no run tree is found.
+            ValueError: If no matching spans are found.
+            ValueError: If multiple matching spans are found and a unique span name is not specified.
+        
+        Example:
+            from getcontext.tracing import capture_trace, Evaluator
+            
+            # Capture a trace
+            trace = capture_trace(my_function)
+
+            # Create an evaluator
+            evaluator = Evaluator(
+                evaluator="golden_response",
+                options={
+                    "golden_response": "[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]",
+                    "capitalization": "full",
+                    "punctuation": "agnostic",
+                    "whitespace": "full"
+                }
+            )
+
+            # Add the evaluator to the span named "my_span"
+            trace.add_evaluator("my_span", evaluator)
+        """
         if span_name == self.run_tree.name:
             raise ValueError("Cannot add evaluator to unit test function.")
 
@@ -22,12 +64,35 @@ class Trace:
         evaluators_options.append(evaluator)
         
         langsmith_run.patch()
+
+    def evaluate(self):
+        """
+        Evaluates the trace by sending it to the server for evaluation.
         
-    def _find_run(self, name: str) -> RunTree:
+        Returns:
+            dict: The evaluation results.
+        """
+        raise NotImplementedError("Not implemented yet.")
+
+    def _find_run(self, span_name: str) -> RunTree:
+        """
+        Finds the run with the specified span_name in the run tree.
+
+        Args:
+            span_name (str): The name of the run to find.
+
+        Returns:
+            RunTree: The matching run.
+
+        Raises:
+            ValueError: If no run tree is found.
+            ValueError: If no matching spans are found.
+            ValueError: If multiple matching spans are found and a unique span_name is not specified.
+        """
         if self.run_tree is None:
             raise ValueError("No run tree found.")
         
-        matching_runs = self._find_run_helper(self.run_tree, name)
+        matching_runs = self._find_run_helper(self.run_tree, span_name)
         
         if len(matching_runs) == 0:
             raise ValueError("No matching spans found.")
@@ -36,13 +101,23 @@ class Trace:
             
         return matching_runs[0]
         
-    def _find_run_helper(self, run_tree: RunTree, name: str) -> RunTree:
-        # recurssion is fine here beacuse we explicitly don't allow complicated deep trees server side
+    def _find_run_helper(self, run_tree: RunTree, span_name: str) -> RunTree:
+        """
+        Helper function to recursively find the run with the specified span_name in the run tree.
+
+        Args:
+            run_tree (RunTree): The current run tree to search.
+            span_name (str): The name of the run to find.
+
+        Returns:
+            RunTree: The matching run.
+        """
+        # recursion is fine here because we explicitly don't allow complicated deep trees server side
         matching_runs = []
         for run in run_tree.child_runs:
-            if run.name == name:
+            if run.name == span_name:
                 matching_runs.append(run)
             else:
-                matching_runs += self._find_run_helper(run, name)
+                matching_runs += self._find_run_helper(run, span_name)
             
         return matching_runs

--- a/tests/test__tools.py
+++ b/tests/test__tools.py
@@ -16,11 +16,8 @@ class TestTools(unittest.TestCase):
         return list(TestTools.fib(a))
     
     def setUp(self):
-        os.environ['CONTEXT_SDK_DEV'] = 'true'
+        os.environ['CONTEXT_TRACE_ENDPOINT'] = 'http://api.localtest.me:3000/api/v1/evaluations/traces'
         os.environ['GETCONTEXT_TOKEN'] = 'TOKEN'
-
-    def tearDown(self):
-        del os.environ['CONTEXT_SDK_DEV']
     
     def test_capture_trace_completes_function(self):
         TestTools.fibonacci_dummy(a=15)

--- a/tests/test__tools.py
+++ b/tests/test__tools.py
@@ -1,5 +1,5 @@
 import unittest
-from getcontext.tracing import Trace, capture_trace, traceable
+from getcontext.tracing import Trace, capture_trace, traceable, Evaluator
 import os
 
 
@@ -26,8 +26,6 @@ class TestTools(unittest.TestCase):
         TestTools.fibonacci_dummy(a=15)
         trace = capture_trace(TestTools.fibonacci_dummy, a=14)
         
-        trace.add_evaluator('fibonacci_dummy', {'smenatic_mathch': 'true'})
-        
         self.assertEqual(trace.result, [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233])
 
     def test_capture_trace_raises_error_on_non_callable(self):
@@ -49,10 +47,19 @@ class TestTools(unittest.TestCase):
     def test_trace_patch(self):
         # NOTE: getting exception from server
         trace = capture_trace(TestTools.fibonacci_dummy)
-        # TODO: add correct evaluator details
-        trace.add_evaluator('fibonacci_dummy', {'smenatic_mathch': 'true'})
+
+        golden_response_evaluator = Evaluator(
+            evaluator='golden_response',
+            options={
+                'golden_response': "[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]",
+                'capitalization': 'full',
+                'punctuation': 'full',
+                'whitespace': 'full'
+                }
+        )
+        trace.add_evaluator('fibonacci_dummy', golden_response_evaluator)
         
-        self.assertEqual(trace.run_tree.child_runs[0].extra['context_ai_options']['evaluators'][0], {'smenatic_mathch': 'true'})
+        self.assertEqual(trace.run_tree.child_runs[0].extra['context_ai_options']['evaluators'][0], golden_response_evaluator)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added some more docs with some examples

Added Evaluator model for hinting. This does not provide much help which is unfortunate. We could do something smart where we make default evaluators their own classes in swagger which will give much better hinting.

Also added a new way to import Evaluator from tracing for ease (unsure if this is a good idea and open to discussion.)

Constants for url endpoints

