### PR TITLE
added less strict versioning for langsmith

### DIFF
--- a/getcontext/tracing/_helpers.py
+++ b/getcontext/tracing/_helpers.py
@@ -2,6 +2,8 @@ import contextlib
 import os
 
 
+CONTEXT_TRACE_ENDPOINT = "https://api.context.ai/api/v1/evaluations/traces"
+
 # Kindly stolen from https://stackoverflow.com/questions/2059482/temporarily-modify-the-current-processs-environment
 @contextlib.contextmanager
 def modified_environ(*remove, **update):
@@ -32,3 +34,30 @@ def modified_environ(*remove, **update):
     finally:
         env.update(update_after)
         [env.pop(k) for k in remove_after]
+
+
+def context_API_key() -> str:
+    """
+    Retrieves the API key for the GetContext service from the environment variables.
+
+    Returns:
+        str: The API key for the GetContext service.
+
+    Raises:
+        KeyError: If the GETCONTEXT_TOKEN environment variable is not set.
+    """
+    context_token = os.environ.get("GETCONTEXT_TOKEN")
+    if context_token is None:
+        raise KeyError("GETCONTEXT_TOKEN is not set in the environment variables.")
+
+    return context_token
+
+
+def context_endpoint() -> str:
+    """
+    Retrieves the context trace endpoint from the environment variable or the default value.
+
+    Returns:
+        str: The context trace endpoint.
+    """
+    return os.environ.get("CONTEXT_TRACE_ENDPOINT", CONTEXT_TRACE_ENDPOINT)

--- a/getcontext/tracing/_tools.py
+++ b/getcontext/tracing/_tools.py
@@ -8,8 +8,6 @@ from langsmith import client as ls_client
 from getcontext.tracing._helpers import modified_environ
 from getcontext.tracing.trace import Trace
 
-# TASK: Try capture gloabl langsmith client, change on begin capture trace and end capture trace
-# Looks like clients try to connect on instantiation, unknown if there is a way to override this
 
 CONTEXT_TRACE_ENDPOINT = "https://api.context.ai/api/v1/evaluations/traces"
 

--- a/getcontext/tracing/trace.py
+++ b/getcontext/tracing/trace.py
@@ -1,6 +1,10 @@
-from langsmith.run_trees import RunTree
 from typing import Any
+
 from getcontext.generated.models import Evaluator
+from getcontext import ContextAPI
+from getcontext.token import Credential
+from getcontext.tracing._helpers import context_API_key
+from langsmith.run_trees import RunTree
 
 
 class Trace:
@@ -18,6 +22,8 @@ class Trace:
     def __init__(self, result: Any, run_tree: RunTree):
         self.result = result
         self.run_tree = run_tree
+
+        self.context_client = ContextAPI(credential=Credential(context_API_key()))
     
     def add_evaluator(self, span_name: str, evaluator: Evaluator):
         """

--- a/poetry.lock
+++ b/poetry.lock
@@ -407,13 +407,13 @@ six = "*"
 
 [[package]]
 name = "langsmith"
-version = "0.1.48"
+version = "0.1.49"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 optional = false
 python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "langsmith-0.1.48-py3-none-any.whl", hash = "sha256:2f8967e2aaaed8881efe6f346590681243b315af8ba8a037d969c299d42071d3"},
-    {file = "langsmith-0.1.48.tar.gz", hash = "sha256:9cd21cd0928123b2bd2363f03515cb1f6a833d9a9f00420240d5132861d15fcc"},
+    {file = "langsmith-0.1.49-py3-none-any.whl", hash = "sha256:cf0db7474c0dfb22015c22bf97f62e850898c3c6af9564dd111c2df225acc1c8"},
+    {file = "langsmith-0.1.49.tar.gz", hash = "sha256:5aee8537763f9d62b3368d79d7bfef881e2bfaa28639011d8d7328770cbd6419"},
 ]
 
 [package.dependencies]
@@ -911,4 +911,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e0be92d8dbfbe351acaf6e1b579b5c622cfafdff0128ae8b3955f18a9b68dc47"
+content-hash = "44ce527559a447b8d3f6e3bc7e43e315e4b6f7038133714f62b10c91f8abf63b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ azure-core = "<2.0.0"
 msrest = "<1.0.0"
 azure-mgmt-core = "<2.0.0"
 aiohttp = "^3.8.4"
-langsmith = "0.1.48"
+langsmith = ">= 0.1.3, <= 0.1.49"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Limiting to v0.1.3 as get runt tree function was renamed in this update. We could support prior to this version by doing some checks our side but only should do this if a customer really wants this.

Also limiting to current version, I suspect it would actually be ok to allow anything up to 0.2.0, happy to discuss.

Also added some further code cleanup, and introduced context ai client in Trace class init dunder method