### PR TITLE
Trace name always must be kwarg arg

### DIFF
--- a/getcontext/tracing/_tools.py
+++ b/getcontext/tracing/_tools.py
@@ -12,7 +12,7 @@ from getcontext.tracing._helpers import (
 from getcontext.tracing.trace import Trace
 
 
-def capture_trace(func, trace_name=None, *args, **kwargs) -> Trace:
+def capture_trace(func, *args, trace_name=None, **kwargs) -> Trace:
     """
     Capture a trace of the given function execution.
 

--- a/getcontext/tracing/trace.py
+++ b/getcontext/tracing/trace.py
@@ -100,9 +100,6 @@ class Trace:
             InternalContextError: If the evaluation fails.
             EvaluationsFailedError: If there are any failed, inconclusive, or partially passed evaluations.
         """
-        # TODO: give good error message if you attempt to evaluate a trace without evaluators
-        # TWO options, keep state locally or hit endpoint and see if error msg says test set does not exist
-
         self.run_tree.client.tracing_queue.join()
 
         run_details = self.context_client.evaluations.run(

--- a/tests/test__tools.py
+++ b/tests/test__tools.py
@@ -43,18 +43,19 @@ class TestTools(unittest.TestCase):
 
     def test_capture_trace_completes_function(self):
         TestTools.fibonacci_dummy(a=15)
-        trace = capture_trace(TestTools.fibonacci_dummy, a=14)
+        trace = capture_trace(TestTools.fibonacci_dummy, a=14, trace_name="my_trace")
 
         self.assertEqual(
             trace.result, [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233]
         )
+        self.assertEqual(trace.run_tree.name, "my_trace")
 
     def test_capture_trace_raises_error_on_non_callable(self):
         with self.assertRaises(TypeError):
             capture_trace(5)
 
     def test_capture_trace_returns_trace_instance(self):
-        trace = capture_trace(TestTools.fibonacci_dummy)
+        trace = capture_trace(TestTools.fibonacci_dummy, 5)
         self.assertIsInstance(trace, Trace)
 
     def test_capture_trace_has_correct_parent_name(self):


### PR DESCRIPTION
Never gets confused for a normal arg.

Also worth considering that every kwarg we add here is reserved and can never be used as a function input.