### PR TITLE
Failures are not counted as such in unittest

### DIFF
--- a/getcontext/tracing/exceptions.py
+++ b/getcontext/tracing/exceptions.py
@@ -1,6 +1,6 @@
 
 
-class ContextException(Exception):
+class ContextException(AssertionError):
     pass
 
 

--- a/getcontext/tracing/trace.py
+++ b/getcontext/tracing/trace.py
@@ -1,6 +1,7 @@
 from typing import Any
 import time
 import logging
+import sys
 
 from getcontext.generated.models import (
     Evaluator,
@@ -13,6 +14,10 @@ from getcontext.token import Credential
 from getcontext.tracing._helpers import context_API_key, context_domain, enforce_https
 from getcontext.tracing.exceptions import EvaluationsFailedError, InternalContextError
 from langsmith.run_trees import RunTree
+
+
+# tells unittest to interpret AssertionError derived exceptions as test failures
+__unittest = True
 
 
 class Trace:
@@ -123,6 +128,9 @@ class Trace:
         failed_msg = self._create_evaluation_fail_msg(failed_evaluation_msgs)
 
         if failed_msg:
+            # set the global variable on the parent stack so unittest will interpret the exception as a test failure
+            if "__unittest" not in sys._getframe(1).f_globals:
+                sys._getframe(1).f_globals["__unittest"] = True
             raise EvaluationsFailedError(failed_msg)
 
         return results


### PR DESCRIPTION
Before they were counted as errors

Also we no longer show stack traces in unittest tests, need to investigate pytest and other frameworks.
<img width="900" alt="Screenshot 2024-05-02 at 15 03 21" src="https://github.com/contextco/context-py/assets/42246229/143d6d79-51ce-4efc-8c79-3f126632d9c9">

